### PR TITLE
Fix flaky parallel CDN fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1306,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1349,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1459,6 +1497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1570,50 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "thiserror",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -1657,6 +1748,8 @@ dependencies = [
  "nom-derive",
  "regex",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "sha2",
  "stderrlog",
  "tokio",
@@ -1682,6 +1775,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -2103,7 +2202,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2301,6 +2412,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ regex = "1.13.1"
 reqwest = "0.13.4"
 sha2 = "0.11.0"
 stderrlog = "0.6.0"
-tokio = { version = "1.53.1", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { version = "1.53.1", features = ["fs", "macros", "rt-multi-thread", "time"] }
 velcro = "0.5.4"
 xml-rs = "1.0.0"
 zip = "8.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,11 @@ nom = "8.0.0"
 nom-derive = "0.10.1"
 regex = "1.13.1"
 reqwest = "0.13.4"
+reqwest-middleware = "0.5.2"
+reqwest-retry = "0.9.1"
 sha2 = "0.11.0"
 stderrlog = "0.6.0"
-tokio = { version = "1.53.1", features = ["fs", "macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.53.1", features = ["fs", "macros", "rt-multi-thread"] }
 velcro = "0.5.4"
 xml-rs = "1.0.0"
 zip = "8.6.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::FutureExt;
 use log::{trace, warn};
+use reqwest_middleware::ClientWithMiddleware;
 use std::collections::HashMap;
 use std::str::from_utf8;
 
@@ -22,7 +23,7 @@ trait BytesFetcher {
 }
 
 #[async_trait]
-impl BytesFetcher for reqwest::Client {
+impl BytesFetcher for ClientWithMiddleware {
     async fn fetch_bytes(&self, url: String, range: Option<(usize, usize)>) -> Result<Bytes> {
         let mut req = self.get(&url);
         if let Some((start, end)) = range {
@@ -133,18 +134,11 @@ impl<T: BytesFetcher + HasCdnPrefixes + Sync> CdnBytesFetcher for T {
             suffix.unwrap_or("")
         );
         trace!("cdn fetch {path}");
-        let mut delay = std::time::Duration::from_millis(250);
-        for attempt in 1..10 {
-            for cdn_prefix in self.cdn_prefixes() {
-                let url = format!("{cdn_prefix}/{path}");
-                match self.fetch_bytes(url, range).await {
-                    Ok(data) => return Ok(data),
-                    Err(msg) => warn!("fetch failed: {msg:#?}"),
-                }
-            }
-            if attempt < 9 {
-                tokio::time::sleep(delay).await;
-                delay = (delay * 2).min(std::time::Duration::from_secs(5));
+        for cdn_prefix in self.cdn_prefixes() {
+            let url = format!("{cdn_prefix}/{path}");
+            match self.fetch_bytes(url, range).await {
+                Ok(data) => return Ok(data),
+                Err(msg) => warn!("fetch failed: {msg:#?}"),
             }
         }
         bail!("fetch failed on all hosts: {}", path)
@@ -233,15 +227,21 @@ fn to_zip_archive_bytes(m: HashMap<String, Vec<u8>>) -> Result<Vec<u8>> {
 }
 
 async fn process(product: &str) -> Result<()> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("building http client")?;
+    let client = reqwest_middleware::ClientBuilder::new(
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .context("building http client")?,
+    )
+    .with(reqwest_retry::RetryTransientMiddleware::new_with_policy(
+        reqwest_retry::policies::ExponentialBackoff::builder().build_with_max_retries(3),
+    ))
+    .build();
     let ((build_config, cdn_config), cdn_prefixes) =
         futures::future::try_join(client.fetch_version(product), client.fetch_cdns(product))
             .await?;
     struct CdnClient {
-        client: reqwest::Client,
+        client: ClientWithMiddleware,
         cdn_prefixes: Vec<String>,
         throttle: tokio::sync::Semaphore,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,13 +133,18 @@ impl<T: BytesFetcher + HasCdnPrefixes + Sync> CdnBytesFetcher for T {
             suffix.unwrap_or("")
         );
         trace!("cdn fetch {path}");
-        for _ in 1..10 {
+        let mut delay = std::time::Duration::from_millis(250);
+        for attempt in 1..10 {
             for cdn_prefix in self.cdn_prefixes() {
                 let url = format!("{cdn_prefix}/{path}");
                 match self.fetch_bytes(url, range).await {
                     Ok(data) => return Ok(data),
                     Err(msg) => warn!("fetch failed: {msg:#?}"),
                 }
+            }
+            if attempt < 9 {
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(std::time::Duration::from_secs(5));
             }
         }
         bail!("fetch failed on all hosts: {}", path)
@@ -228,7 +233,10 @@ fn to_zip_archive_bytes(m: HashMap<String, Vec<u8>>) -> Result<Vec<u8>> {
 }
 
 async fn process(product: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("building http client")?;
     let ((build_config, cdn_config), cdn_prefixes) =
         futures::future::try_join(client.fetch_version(product), client.fetch_cdns(product))
             .await?;


### PR DESCRIPTION
## Summary
- The archive-index fetch (`process()` in `src/main.rs`) pulls hundreds of files in parallel via `try_join_all`, throttled to 5 concurrent requests. A single stalled connection could hang forever (no request timeout was set) and permanently tie up one of only 5 slots, and the retry loop in `fetch_cdn_bytes` hammered failing hosts immediately with no delay between rounds — so transient blips never had a chance to clear before the whole batch failed.
- Added a 30s timeout to the `reqwest::Client`.
- Replaced the retry loop with the standard `reqwest-middleware` + `reqwest-retry` combo (`ExponentialBackoff`, 3 retries per request) instead of hand-rolling backoff. The outer loop across CDN host prefixes is kept since falling back to a different host is domain-specific logic the retry middleware doesn't know about.

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo fmt --check` / `cargo clippy` (via pre-commit hooks on commit)
- [ ] Run a real extraction against a product to confirm reduced flakiness in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YShoksx2cUJE1uVQwskS31