### PR TITLE
Replace ManifestInterfaceTOCData.db2 with ui-toc-list text files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -324,27 +324,26 @@ async fn process(product: &str) -> Result<()> {
         Ok(bytes)
     };
     let fetch_fdid = |fdid| async move { fetch_content(root.f2c(fdid)?).await };
+    let fetch_name = |name: &'static str| async move { fetch_content(root.n2c(name)?).await };
     let fdids = db2::strings(&fetch_fdid(FileDataID(1375801)).await?)?
         .into_iter()
         .map(|(k, v)| (v.join("").to_lowercase(), FileDataID(k)))
         .collect::<HashMap<String, FileDataID>>();
+    let mut stack = Vec::<String>::new();
+    for listfile in [
+        "Interface\\ui-toc-list.txt",
+        "Interface\\ui-gen-addon-list.txt",
+    ] {
+        for line in from_utf8(&fetch_name(listfile).await?)?.lines() {
+            let line = line.trim();
+            if !line.is_empty() && root.n2c(line).is_ok() {
+                stack.push(line.to_string());
+            }
+        }
+    }
     tokio::fs::write(
         format!("zips/{product}.zip"),
         to_zip_archive_bytes({
-            let mut stack: Vec<String> = db2::strings(&fetch_fdid(FileDataID(1267335)).await?)?
-                .into_values()
-                .flatten()
-                .chain(["Interface\\FrameXML\\".to_string()])
-                .filter_map(|s| {
-                    let dirname = s[..s.len() - 1].split('\\').next_back()?;
-                    let toc1 = format!("{s}{dirname}_{product}.toc");
-                    let toc2 = format!("{s}{dirname}.toc");
-                    root.n2c(&toc1)
-                        .and(Ok(toc1))
-                        .or_else(|_| root.n2c(&toc2).and(Ok(toc2)))
-                        .ok()
-                })
-                .collect();
             let pb = &indicatif::ProgressBar::new(stack.len() as u64);
             let mut result = HashMap::<String, Vec<u8>>::new();
             while let Some(file) = stack.pop() {


### PR DESCRIPTION
## Summary
- `FileDataID(1267335)` ("ManifestInterfaceTOCData.db2") is no longer part of the build for `wow_classic_era` or `wowt` — this was the previously-identified "second issue" (`Error: missing fdid in root`) left out of scope in #194.
- Blizzard replaced it with two plain-text files. Followed `wowless`'s `tools/fetch.lua`, which fetches `Interface/ui-toc-list.txt` and `Interface/ui-gen-addon-list.txt` directly by name instead of going through a DB2 manifest.
- Each line in those files is already a concrete, fully-suffixed `.toc` path (e.g. `Interface\AddOns\Blizzard_AchievementUI\Blizzard_AchievementUI_Classic.toc`), and every suffix variant across all game types is listed in the same file. So rather than reproducing wowless's whole gametype/suffix-matching machinery, this just tries `root.n2c()` on each line directly and keeps whichever ones resolve for the current product's build — that's sufficient to pick out exactly the right variant.
- This also naturally covers the FrameXML entry point, since it's listed there too (now `Blizzard_FrameXML` under `AddOns`, not `Interface\FrameXML\`), so the old hardcoded fallback for that is dropped as dead code.

## Verification
- Inspected the real file contents for both products via `tactless name <product> Interface/ui-toc-list.txt` — confirmed every line ends in `.toc`, no duplicates, and `Blizzard_FrameXML` variants are present.
- Ran `framexml wow_classic_era` and `framexml wowt` against live CDN data end-to-end:
  - `wow_classic_era.zip`: 2266 files
  - `wowt.zip`: 2953 files
  - Both previously failed outright with `missing fdid in root`.

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo fmt` / `cargo clippy` (via pre-commit hooks)
- [x] Ran `framexml wow_classic_era` and `framexml wowt` against live CDN data — both complete successfully and produce populated zips

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YShoksx2cUJE1uVQwskS31